### PR TITLE
docs: fix remaining course typos from issue 72

### DIFF
--- a/assessments-certification.en.adoc
+++ b/assessments-certification.en.adoc
@@ -39,7 +39,7 @@ Review the rubrics to ensure understanding of the skills that will be assessed f
 |Shows understanding of a few roles and tasks required in a solid mobilization plan, but is not able to differentiate who performs each task in the plan or mixes up the roles.
 |Understands many of the roles and tasks needed in a mobilization plan, but still misses links and interactions between them.
 |Understands the key tasks and roles needed in a mobilization plan and how they interact.
-|Can identify additional roles and task that may be needed for specific situations
+|Can identify additional roles and tasks that may be needed for specific situations
 
 |B. Capacity to apply the different elements of a biodiversity data mobilization plan to a given institutional context (e.g. their own)
 |Can see how a few of the tasks and roles relate to a given institutional context, but has difficulties when the context changes even slightly from the generic references used.
@@ -131,7 +131,7 @@ Review the rubrics to ensure understanding of the skills that will be assessed f
 
 |D. Capacity to perform geographical data correction.
 |Can only make corrections manually in the tables. Only uses personal knowledge of known geographical areas.
-|Can identify at least one specific tool to map and/or automatically correct errors in geographical information, but can only use it in specific cases. Otherwise, uses simple mechanisms (e.g. ‘find & replace3’) to solve issues.
+|Can identify at least one specific tool to map and/or automatically correct errors in geographical information, but can only use it in specific cases. Otherwise, uses simple mechanisms (e.g. ‘find and replace’) to solve issues.
 |Can use at least one tool to map and/or automatically correct errors in geographical information. Can find and use suitable reference geographical information in a suitable format for the areas with which (s)he usually works.
 |Can use more than one tool to map and/or automatically correct errors in geographical information. Can find and use reference geographical information in a suitable format for areas outside of his/her areas of expertise.
 

--- a/capture.en.adoc
+++ b/capture.en.adoc
@@ -8,7 +8,7 @@ Lastly, you will review principles of data quality in the context of data captur
 === Standards and Darwin Core
 [NOTE.presentation]
 In this video (15:37), you will learn how you interact with standards every day. 
-Then you will be introduced to https://www.tdwg.org/[Biodiversity Information Standards^], including the https://www.tdwg.org/standards/dwc/[Darwin Core Standard^] with which you will continue to use throughout this course.
+Then you will be introduced to https://www.tdwg.org/[Biodiversity Information Standards^], including the https://www.tdwg.org/standards/dwc/[Darwin Core Standard^], which you will continue to use throughout this course.
 If you are unable to watch the embedded video, you can link:../videos/Foundations_Standards_Darwin_Core.mp4[download^,opts=download] it locally. (MP4 - 27 MB)
 
 [.responsive-video]
@@ -140,7 +140,7 @@ image::img/web/QDataTypes-traps.png[align="center",width=640,height=360]
 +
 [question, mc]
 ....
-Data acquired in the context of protected areas management (such as national parks but also smaller nature reserves) can be diverse and have different origins: botanical surveys, tagged animals tracking, observations from rangers and guards, and even ‘citizen science’ data or data inferred from pictures shared on social medias.
+Data acquired in the context of protected areas management (such as national parks but also smaller nature reserves) can be diverse and have different origins: botanical surveys, tagged animals tracking, observations from rangers and guards, and even ‘citizen science’ data or data inferred from pictures shared on social media.
 
 :figure-caption!:
 .https://pixabay.com/photos/%C3%A9l%C3%A9phant-%C3%A9l%C3%A9phant-d-asie-4037451/[Sri Lankan elephants] observed by pen_ash.


### PR DESCRIPTION
## Summary
- fix four currently reproducible typos from issue #72 in the course AsciiDoc sources
- update the Darwin Core sentence, the social media wording, the rubric pluralization, and the stray "find and replace" text

## Validation
- git diff --check

Closes #72
