### PR TITLE
docs: rename the use-case heading from Roles to People

### DIFF
--- a/use-case-invasive-species.en.adoc
+++ b/use-case-invasive-species.en.adoc
@@ -97,7 +97,7 @@ The new project has the following people available for data processing and mobil
 . Assign roles to maximize the efficiency of the data processing and transformation to produce data of the highest quality as efficiently as possible? 
 . Use the exercise sheet to provide your answers.
 
-*Roles*
+*People*
 
 * BIISC GIS Analyst: Advanced computer use, GIS and data analysis tools.
 * ISC Manager: Good computer skills.


### PR DESCRIPTION
## Summary
- rename the exercise heading from `Roles` to `People`
- keep the wording aligned with the preceding sentence about the people available for mobilization work

## Validation
- reviewed the rendered source context locally to confirm the heading now matches the surrounding text

Closes #57