### PR TITLE
docs: add taxonomy and nomenclature references to prerequisites

### DIFF
--- a/description.en.adoc
+++ b/description.en.adoc
@@ -29,7 +29,7 @@ The instruction provided is particularly useful for those who have a need or des
 . Additionally, to make best use of the activities around this course, the participants should possess the following skills and knowledge:
 
 * Basic skills in computer and internet use, and, in particular, in the use of spreadsheets.
-* Basic knowledge about geography and biodiversity informatics: geography and mapping concepts, basic taxonomy and nomenclature rules.
+* Basic knowledge about geography and biodiversity informatics: geography and mapping concepts, basic https://en.wikipedia.org/wiki/Taxonomy_(biology)[taxonomy^] and https://en.wikipedia.org/wiki/Biological_nomenclature[nomenclature^] rules.
 * Willingness to disseminate the knowledge learned in the workshop with partners and collaborators in your project by adapting the biodiversity data mobilization training materials to specific contexts and languages while maintaining their instructional value.
 * A good command of English. While efforts are made to provide materials in other languages, instruction/videos will be in English.
 


### PR DESCRIPTION
## Summary
- add direct reference links for the taxonomy and nomenclature background mentioned in the prerequisites
- keep the change narrowly scoped to the course description page

## Validation
- reviewed the updated AsciiDoc source to confirm both external links are embedded in the prerequisite bullet

Closes #52